### PR TITLE
工作: 重新編排不同層級的按鍵映射

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -239,7 +239,7 @@
             label = "WinFunc";
             bindings = <
 &none  &kp F1                &kp F2   &kp F3          &kp F4            &kp F5        &bt BT_SEL 0  &bt BT_SEL 1     &bt BT_SEL 2       &bt BT_SEL 3  &bt BT_SEL 4  &none
-&none  &kp F6                &kp F7   &kp F8          &kp F9            &kp F10       &bt BT_CLR    &none            &none              &to GAME_DEF  &to MAC_DEF   &none
+&none  &kp F6                &kp F7   &kp F8          &kp F9            &kp F10       &bt BT_CLR    &to MAC_DEF      &to GAME_DEF       &none         &none         &none
 &none  &mt LEFT_CONTROL F11  &kp F12  &kp C_PREVIOUS  &kp C_PLAY_PAUSE  &kp C_NEXT    &kp C_MUTE    &kp C_VOLUME_UP  &kp C_VOLUME_DOWN  &none         &none         &none
                                       &trans          &trans            &trans        &trans        &trans           &trans
             >;
@@ -279,7 +279,7 @@
             label = "MacFunc";
             bindings = <
 &none  &kp F1                &kp F2   &kp F3          &kp F4            &kp F5        &bt BT_SEL 0  &bt BT_SEL 1     &bt BT_SEL 2        &bt BT_SEL 3  &bt BT_SEL 4  &none
-&none  &kp F6                &kp F7   &kp F8          &kp F9            &kp F10       &bt BT_CLR    &none            &none               &to GAME_DEF  &to WIN_DEF   &none
+&none  &kp F6                &kp F7   &kp F8          &kp F9            &kp F10       &bt BT_CLR    &to WIN_DEF      &to GAME_DEF        &none         &none         &none
 &none  &mt LEFT_CONTROL F11  &kp F12  &kp C_PREVIOUS  &kp C_PLAY_PAUSE  &kp C_NEXT    &kp C_MUTE    &kp C_VOLUME_UP  &kp C_VOLUME_DOWN   &none         &none         &none
                                       &trans          &trans            &trans        &trans        &trans           &trans
             >;
@@ -298,10 +298,10 @@
         game_option_layer {
             label = "Option";
             bindings = <
-&none  &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3  &kp NUMBER_4  &kp NUMBER_5    &none  &none  &none  &none  &none        &none
-&none  &kp NUMBER_6  &kp NUMBER_7  &kp NUMBER_8  &kp NUMBER_9  &kp NUMBER_0    &none  &none  &none  &none  &to WIN_DEF  &none
-&none  &kp G         &none         &none         &none         &kp B           &none  &none  &none  &none  &none        &none
-                                   &none         &trans        &trans          &none  &none  &none
+&none  &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3  &kp NUMBER_4  &kp NUMBER_5    &none  &none        &none        &none  &none  &none
+&none  &kp NUMBER_6  &kp NUMBER_7  &kp NUMBER_8  &kp NUMBER_9  &kp NUMBER_0    &none  &to WIN_DEF  &to MAC_DEF  &none  &none  &none
+&none  &kp G         &none         &none         &none         &kp B           &none  &none        &none        &none  &none  &none
+                                   &none         &trans        &trans          &none  &none        &none
             >;
         };
     };

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -157,28 +157,12 @@
     };
 
     behaviors {
-        td_multi_win: tap_dance_multi_win {
-            compatible = "zmk,behavior-tap-dance";
-            label = "TAP_DANCE_MULTI_WIN";
-            #binding-cells = <0>;
-            tapping-term-ms = <200>;
-            bindings = <&sk LEFT_GUI>, <&terminal_win>, <&screenshot_win>;
-        };
-
         td_multi_alt: tap_dance_multi_alt {
             compatible = "zmk,behavior-tap-dance";
             label = "TAP_DANCE_MULTI_ALT";
             #binding-cells = <0>;
             tapping-term-ms = <200>;
             bindings = <&kp LEFT_ALT>, <&kp LA(LEFT_SHIFT)>;
-        };
-
-        td_multi_mac: tap_dance_multi_mac {
-            compatible = "zmk,behavior-tap-dance";
-            label = "TAP_DANCE_MULTI_MAC";
-            #binding-cells = <0>;
-            tapping-term-ms = <200>;
-            bindings = <&kp LEFT_ALT>, <&spotlight>, <&screenshot_mac>;
         };
 
         dm: del_mod {
@@ -199,6 +183,22 @@
             quick-tap-ms = <125>;
             flavor = "balanced";
             bindings = <&kp>, <&kp>;
+        };
+
+        td_multi_win: tap_dance_multi_win {
+            compatible = "zmk,behavior-tap-dance";
+            label = "TAP_DANCE_MULTI_WIN";
+            #binding-cells = <0>;
+            tapping-term-ms = <200>;
+            bindings = <&sk LEFT_GUI>, <&terminal_win>, <&screenshot_win>;
+        };
+
+        td_multi_mac: tap_dance_multi_mac {
+            compatible = "zmk,behavior-tap-dance";
+            label = "TAP_DANCE_MULTI_MAC";
+            #binding-cells = <0>;
+            tapping-term-ms = <200>;
+            bindings = <&kp LEFT_ALT>, <&spotlight>, <&screenshot_mac>;
         };
     };
 
@@ -239,7 +239,7 @@
             label = "WinFunc";
             bindings = <
 &none  &kp F1                &kp F2   &kp F3          &kp F4            &kp F5        &bt BT_SEL 0  &bt BT_SEL 1     &bt BT_SEL 2       &bt BT_SEL 3  &bt BT_SEL 4  &none
-&none  &kp F6                &kp F7   &kp F8          &kp F9            &kp F10       &bt BT_CLR    &to MAC_DEF      &to GAME_DEF       &none         &none         &none
+&none  &kp F6                &kp F7   &kp F8          &kp F9            &kp F10       &bt BT_CLR    &none            &none              &to GAME_DEF  &to MAC_DEF   &none
 &none  &mt LEFT_CONTROL F11  &kp F12  &kp C_PREVIOUS  &kp C_PLAY_PAUSE  &kp C_NEXT    &kp C_MUTE    &kp C_VOLUME_UP  &kp C_VOLUME_DOWN  &none         &none         &none
                                       &trans          &trans            &trans        &trans        &trans           &trans
             >;
@@ -279,7 +279,7 @@
             label = "MacFunc";
             bindings = <
 &none  &kp F1                &kp F2   &kp F3          &kp F4            &kp F5        &bt BT_SEL 0  &bt BT_SEL 1     &bt BT_SEL 2        &bt BT_SEL 3  &bt BT_SEL 4  &none
-&none  &kp F6                &kp F7   &kp F8          &kp F9            &kp F10       &bt BT_CLR    &to WIN_DEF      &to GAME_DEF        &none         &none         &none
+&none  &kp F6                &kp F7   &kp F8          &kp F9            &kp F10       &bt BT_CLR    &none            &none               &to GAME_DEF  &to WIN_DEF   &none
 &none  &mt LEFT_CONTROL F11  &kp F12  &kp C_PREVIOUS  &kp C_PLAY_PAUSE  &kp C_NEXT    &kp C_MUTE    &kp C_VOLUME_UP  &kp C_VOLUME_DOWN   &none         &none         &none
                                       &trans          &trans            &trans        &trans        &trans           &trans
             >;
@@ -298,10 +298,10 @@
         game_option_layer {
             label = "Option";
             bindings = <
-&none  &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3  &kp NUMBER_4  &kp NUMBER_5    &none  &none        &none        &none  &none  &none
-&none  &kp NUMBER_6  &kp NUMBER_7  &kp NUMBER_8  &kp NUMBER_9  &kp NUMBER_0    &none  &to WIN_DEF  &to MAC_DEF  &none  &none  &none
-&none  &kp G         &none         &none         &none         &kp B           &none  &none        &none        &none  &none  &none
-                                   &none         &trans        &trans          &none  &none        &none
+&none  &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3  &kp NUMBER_4  &kp NUMBER_5    &none  &none  &none  &none  &none        &none
+&none  &kp NUMBER_6  &kp NUMBER_7  &kp NUMBER_8  &kp NUMBER_9  &kp NUMBER_0    &none  &none  &none  &none  &to WIN_DEF  &none
+&none  &kp G         &none         &none         &none         &kp B           &none  &none  &none  &none  &none        &none
+                                   &none         &trans        &trans          &none  &none  &none
             >;
         };
     };


### PR DESCRIPTION
- 修改了 `config/corne.keymap` 中的 `windows_function_layer` 的按鍵映射
- 修改了 `config/corne.keymap` 中的 `mac_function_layer` 的按鍵映射
- 修改了 `config/corne.keymap` 中的 `game_option_layer` 的按鍵映射
