### PR TITLE
重構：更新退格鍵和刪除鍵的綁定

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -114,7 +114,7 @@
         };
 
         combo_BACKSPACE {
-            bindings = <&kp BACKSPACE>;
+            bindings = <&bspc_del>;
             key-positions = <9 10>;
             timeout-ms = <100>;
             layers = <0 1 2 3 4 5 6 7>;
@@ -165,16 +165,6 @@
             bindings = <&kp LEFT_ALT>, <&kp LA(LEFT_SHIFT)>;
         };
 
-        dm: del_mod {
-            compatible = "zmk,behavior-hold-tap";
-            label = "DEL_MOD";
-            #binding-cells = <2>;
-            tapping-term-ms = <200>;
-            quick-tap-ms = <125>;
-            flavor = "balanced";
-            bindings = <&kp>, <&kp>;
-        };
-
         sm: space_mod {
             compatible = "zmk,behavior-hold-tap";
             label = "SPACE_MOD";
@@ -200,6 +190,13 @@
             tapping-term-ms = <200>;
             bindings = <&kp LEFT_ALT>, <&spotlight>, <&screenshot_mac>;
         };
+
+        bspc_del: backspace_delete {
+            compatible = "zmk,behavior-mod-morph";
+            #binding-cells = <0>;
+            bindings = <&kp BACKSPACE>, <&kp DELETE>;
+            mods = <(MOD_LSFT)>;
+        };
     };
 
     keymap {
@@ -211,7 +208,7 @@
 &none  &kp Q               &kp W  &kp E          &kp R         &kp T                   &kp Y      &kp U        &kp I               &kp O    &kp P          &none
 &none  &kp A               &kp S  &kp D          &kp F         &kp G                   &kp H      &kp J        &kp K               &kp L    &kp SEMICOLON  &none
 &none  &mt LEFT_CONTROL Z  &kp X  &kp C          &kp V         &kp B                   &kp N      &kp M        &kp COMMA           &kp DOT  &kp SLASH      &none
-                                  &td_multi_alt  &mo WIN_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER  &mo WIN_NUM  &dm LC(LEFT_SHIFT) DELETE
+                                  &td_multi_alt  &mo WIN_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER  &mo WIN_NUM  &kp LC(LEFT_SHIFT)
             >;
         };
 
@@ -251,7 +248,7 @@
 &none  &kp Q               &kp W  &kp E          &kp R         &kp T                   &kp Y      &kp U        &kp I                         &kp O    &kp P          &none
 &none  &kp A               &kp S  &kp D          &kp F         &kp G                   &kp H      &kp J        &kp K                         &kp L    &kp SEMICOLON  &none
 &none  &mt LEFT_CONTROL Z  &kp X  &kp C          &kp V         &kp B                   &kp N      &kp M        &kp COMMA                     &kp DOT  &kp SLASH      &none
-                                  &kp LEFT_GUI   &mo MAC_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER  &mo MAC_NUM  &dm LC(LEFT_SHIFT) DELETE
+                                  &kp LEFT_GUI   &mo MAC_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER  &mo MAC_NUM  &kp LC(LEFT_SHIFT)
             >;
         };
 

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -239,7 +239,7 @@
             label = "WinFunc";
             bindings = <
 &none  &kp F1                &kp F2   &kp F3          &kp F4            &kp F5        &bt BT_SEL 0  &bt BT_SEL 1     &bt BT_SEL 2       &bt BT_SEL 3  &bt BT_SEL 4  &none
-&none  &kp F6                &kp F7   &kp F8          &kp F9            &kp F10       &bt BT_CLR    &none            &none              &to GAME_DEF  &to MAC_DEF   &none
+&none  &kp F6                &kp F7   &kp F8          &kp F9            &kp F10       &bt BT_CLR    &to MAC_DEF      &to GAME_DEF       &none         &none         &none
 &none  &mt LEFT_CONTROL F11  &kp F12  &kp C_PREVIOUS  &kp C_PLAY_PAUSE  &kp C_NEXT    &kp C_MUTE    &kp C_VOLUME_UP  &kp C_VOLUME_DOWN  &none         &none         &none
                                       &trans          &trans            &trans        &trans        &trans           &trans
             >;
@@ -279,7 +279,7 @@
             label = "MacFunc";
             bindings = <
 &none  &kp F1                &kp F2   &kp F3          &kp F4            &kp F5        &bt BT_SEL 0  &bt BT_SEL 1     &bt BT_SEL 2        &bt BT_SEL 3  &bt BT_SEL 4  &none
-&none  &kp F6                &kp F7   &kp F8          &kp F9            &kp F10       &bt BT_CLR    &none            &none               &to GAME_DEF  &to WIN_DEF   &none
+&none  &kp F6                &kp F7   &kp F8          &kp F9            &kp F10       &bt BT_CLR    &to WIN_DEF      &to GAME_DEF        &none         &none         &none
 &none  &mt LEFT_CONTROL F11  &kp F12  &kp C_PREVIOUS  &kp C_PLAY_PAUSE  &kp C_NEXT    &kp C_MUTE    &kp C_VOLUME_UP  &kp C_VOLUME_DOWN   &none         &none         &none
                                       &trans          &trans            &trans        &trans        &trans           &trans
             >;
@@ -298,10 +298,10 @@
         game_option_layer {
             label = "Option";
             bindings = <
-&none  &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3  &kp NUMBER_4  &kp NUMBER_5    &none  &none  &none  &none  &none        &none
-&none  &kp NUMBER_6  &kp NUMBER_7  &kp NUMBER_8  &kp NUMBER_9  &kp NUMBER_0    &none  &none  &none  &none  &to WIN_DEF  &none
-&none  &kp G         &none         &none         &none         &kp B           &none  &none  &none  &none  &none        &none
-                                   &none         &trans        &trans          &none  &none  &none
+&none  &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3  &kp NUMBER_4  &kp NUMBER_5    &none  &none        &none        &none  &none  &none
+&none  &kp NUMBER_6  &kp NUMBER_7  &kp NUMBER_8  &kp NUMBER_9  &kp NUMBER_0    &none  &to WIN_DEF  &to MAC_DEF  &none  &none  &none
+&none  &kp G         &none         &none         &none         &kp B           &none  &none        &none        &none  &none  &none
+                                   &none         &trans        &trans          &none  &none        &none
             >;
         };
     };


### PR DESCRIPTION
- 將`combo_BACKSPACE`的綁定從`&amp;lt;&amp;amp;kp BACKSPACE&amp;gt;`修改為`&amp;lt;&amp;amp;bspc_del&amp;gt;`
- 刪除`dm: del_mod`的行為
- 添加`bspc_del: backspace_delete`的行為，綁定為`&amp;lt;&amp;amp;kp BACKSPACE&amp;gt;, &amp;lt;&amp;amp;kp DELETE&amp;gt;`，並加上修飾符`&amp;lt;(MOD_LSFT)&amp;gt;`
- 修改`windows_code_layer`中的`bindings`，刪除`&amp;amp;dm LC(LEFT_SHIFT) DELETE`，添加`&amp;amp;kp LC(LEFT_SHIFT)`
- 修改`mac_code_layer`中的`bindings`，刪除`&amp;amp;dm LC(LEFT_SHIFT) DELETE`，添加`&amp;amp;kp LC(LEFT_SHIFT)`
