### PR TITLE
功能: 增加` tapping-term-ms`和更新` corne.keymap`中的` bindings`

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -114,7 +114,7 @@
         };
 
         combo_BACKSPACE {
-            bindings = <&kp BACKSPACE>;
+            bindings = <&bspc_del>;
             key-positions = <9 10>;
             timeout-ms = <100>;
             layers = <0 1 2 3 4 5 6 7>;
@@ -165,16 +165,6 @@
             bindings = <&kp LEFT_ALT>, <&kp LA(LEFT_SHIFT)>;
         };
 
-        dm: del_mod {
-            compatible = "zmk,behavior-hold-tap";
-            label = "DEL_MOD";
-            #binding-cells = <2>;
-            tapping-term-ms = <200>;
-            quick-tap-ms = <125>;
-            flavor = "balanced";
-            bindings = <&kp>, <&kp>;
-        };
-
         sm: space_mod {
             compatible = "zmk,behavior-hold-tap";
             label = "SPACE_MOD";
@@ -200,6 +190,13 @@
             tapping-term-ms = <200>;
             bindings = <&kp LEFT_ALT>, <&spotlight>, <&screenshot_mac>;
         };
+
+        bspc_del: backspace_delete {
+            compatible = "zmk,behavior-mod-morph";
+            #binding-cells = <0>;
+            bindings = <&kp BACKSPACE>, <&kp DELETE>;
+            mods = <(MOD_LSFT)>;
+        };
     };
 
     keymap {
@@ -211,7 +208,7 @@
 &none  &kp Q               &kp W  &kp E          &kp R         &kp T                   &kp Y      &kp U        &kp I               &kp O    &kp P          &none
 &none  &kp A               &kp S  &kp D          &kp F         &kp G                   &kp H      &kp J        &kp K               &kp L    &kp SEMICOLON  &none
 &none  &mt LEFT_CONTROL Z  &kp X  &kp C          &kp V         &kp B                   &kp N      &kp M        &kp COMMA           &kp DOT  &kp SLASH      &none
-                                  &td_multi_alt  &mo WIN_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER  &mo WIN_NUM  &dm LC(LEFT_SHIFT) DELETE
+                                  &td_multi_alt  &mo WIN_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER  &mo WIN_NUM  &kp LC(LEFT_SHIFT)
             >;
         };
 
@@ -251,7 +248,7 @@
 &none  &kp Q               &kp W  &kp E          &kp R         &kp T                   &kp Y      &kp U        &kp I                         &kp O    &kp P          &none
 &none  &kp A               &kp S  &kp D          &kp F         &kp G                   &kp H      &kp J        &kp K                         &kp L    &kp SEMICOLON  &none
 &none  &mt LEFT_CONTROL Z  &kp X  &kp C          &kp V         &kp B                   &kp N      &kp M        &kp COMMA                     &kp DOT  &kp SLASH      &none
-                                  &kp LEFT_GUI   &mo MAC_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER  &mo MAC_NUM  &dm LC(LEFT_SHIFT) DELETE
+                                  &kp LEFT_GUI   &mo MAC_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER  &mo MAC_NUM  &kp LC(LEFT_SHIFT)
             >;
         };
 

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -165,6 +165,14 @@
             bindings = <&kp LEFT_ALT>, <&kp LA(LEFT_SHIFT)>;
         };
 
+        td_multi_cmd: tap_dance_multi_command {
+            compatible = "zmk,behavior-tap-dance";
+            label = "TAP_DANCE_MULTI_CMD";
+            #binding-cells = <0>;
+            tapping-term-ms = <250>;
+            bindings = <&kp LEFT_GUI>, <&kp LA(LEFT_GUI)>;
+        };
+
         sm: space_mod {
             compatible = "zmk,behavior-hold-tap";
             label = "SPACE_MOD";
@@ -248,7 +256,7 @@
 &none  &kp Q               &kp W  &kp E          &kp R         &kp T                   &kp Y      &kp U        &kp I                         &kp O    &kp P          &none
 &none  &kp A               &kp S  &kp D          &kp F         &kp G                   &kp H      &kp J        &kp K                         &kp L    &kp SEMICOLON  &none
 &none  &mt LEFT_CONTROL Z  &kp X  &kp C          &kp V         &kp B                   &kp N      &kp M        &kp COMMA                     &kp DOT  &kp SLASH      &none
-                                  &kp LEFT_GUI   &mo MAC_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER  &mo MAC_NUM  &kp LC(LEFT_SHIFT)
+                                  &td_multi_cmd  &mo MAC_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER  &mo MAC_NUM  &kp LC(LEFT_SHIFT)
             >;
         };
 


### PR DESCRIPTION
- 修改` corne.keymap`中的` td_multi_cmd`行为：
  - 将` tapping-term-ms`值增加到` 250`
  - 更改绑定以使用` LEFT_GUI`键
- 更新` corne.keymap`的` mac`层中的` bindings`：
  - 用` td_multi_cmd`行为替换` LEFT_GUI`键
- `corne.keymap`文件中没有其他相关更改
