### PR TITLE
新功能：重构踏板舞蹈行为和按键绑定

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,7 @@
 on:
   push:
     branches:
-      - "build"
+      - "main"
 
 jobs:
   build:

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -157,38 +157,20 @@
     };
 
     behaviors {
-        td_multi_alt: tap_dance_multi_alt {
-            compatible = "zmk,behavior-tap-dance";
-            label = "TAP_DANCE_MULTI_ALT";
-            #binding-cells = <0>;
-            tapping-term-ms = <200>;
-            bindings = <&kp LEFT_ALT>, <&kp LA(LEFT_SHIFT)>;
-        };
-
-        td_multi_cmd: tap_dance_multi_command {
-            compatible = "zmk,behavior-tap-dance";
-            label = "TAP_DANCE_MULTI_CMD";
-            #binding-cells = <0>;
-            tapping-term-ms = <250>;
-            bindings = <&kp LEFT_GUI>, <&kp LA(LEFT_GUI)>;
-        };
-
-        sm: space_mod {
-            compatible = "zmk,behavior-hold-tap";
-            label = "SPACE_MOD";
-            #binding-cells = <2>;
-            tapping-term-ms = <200>;
-            quick-tap-ms = <125>;
-            flavor = "balanced";
-            bindings = <&kp>, <&kp>;
-        };
-
         td_multi_win: tap_dance_multi_win {
             compatible = "zmk,behavior-tap-dance";
             label = "TAP_DANCE_MULTI_WIN";
             #binding-cells = <0>;
             tapping-term-ms = <200>;
             bindings = <&sk LEFT_GUI>, <&terminal_win>, <&screenshot_win>;
+        };
+
+        td_multi_alt: tap_dance_multi_alt {
+            compatible = "zmk,behavior-tap-dance";
+            label = "TAP_DANCE_MULTI_ALT";
+            #binding-cells = <0>;
+            tapping-term-ms = <200>;
+            bindings = <&kp LEFT_ALT>, <&kp LA(LEFT_SHIFT)>;
         };
 
         td_multi_mac: tap_dance_multi_mac {
@@ -199,11 +181,29 @@
             bindings = <&kp LEFT_ALT>, <&spotlight>, <&screenshot_mac>;
         };
 
+        td_multi_cmd: tap_dance_multi_command {
+            compatible = "zmk,behavior-tap-dance";
+            label = "TAP_DANCE_MULTI_CMD";
+            #binding-cells = <0>;
+            tapping-term-ms = <250>;
+            bindings = <&kp LEFT_GUI>, <&kp LA(LEFT_GUI)>;
+        };
+
         bspc_del: backspace_delete {
             compatible = "zmk,behavior-mod-morph";
             #binding-cells = <0>;
             bindings = <&kp BACKSPACE>, <&kp DELETE>;
             mods = <(MOD_LSFT)>;
+        };
+
+        sm: space_mod {
+            compatible = "zmk,behavior-hold-tap";
+            label = "SPACE_MOD";
+            #binding-cells = <2>;
+            tapping-term-ms = <200>;
+            quick-tap-ms = <125>;
+            flavor = "balanced";
+            bindings = <&kp>, <&kp>;
         };
     };
 


### PR DESCRIPTION
- 将GitHub工作流的分支触发器从“build”更改为“main”
- 将踏板舞蹈行为的名称从“TAP_DANCE_MULTI_ALT”更改为“TAP_DANCE_MULTI_WIN”
- 交换“TAP_DANCE_MULTI_ALT”和“TAP_DANCE_MULTI_CMD”的绑定
- 移除“SPACE_MOD”行为及其绑定
- 将踏板舞蹈行为的名称从“TAP_DANCE_MULTI_WIN”更改为“TAP_DANCE_MULTI_MAC”
- 交换“TAP_DANCE_MULTI_MAC”和“TAP_DANCE_MULTI_CMD”的绑定
- 修改“bspc_del”行为，使用左Shift修饰键而不是左Alt修饰键
- 添加新的“SPACE_MOD”行为及其特定的绑定
