### PR TITLE
重構：更新遊戲選項和圖層的按鍵綁定

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -303,8 +303,8 @@
         game_option_layer {
             label = "Option";
             bindings = <
-&none  &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3  &kp NUMBER_4  &kp NUMBER_5    &none  &none        &none        &none  &none  &none
-&none  &kp NUMBER_6  &kp NUMBER_7  &kp NUMBER_8  &kp NUMBER_9  &kp NUMBER_0    &none  &to WIN_DEF  &to MAC_DEF  &none  &none  &none
+&none  &kp NUMBER_5  &kp NUMBER_4  &kp NUMBER_3  &kp NUMBER_2  &kp NUMBER_1    &none  &none        &none        &none  &none  &none
+&none  &kp NUMBER_0  &kp NUMBER_9  &kp NUMBER_8  &kp NUMBER_7  &kp NUMBER_6    &none  &to WIN_DEF  &to MAC_DEF  &none  &none  &none
 &none  &kp G         &none         &none         &none         &kp B           &none  &none        &none        &none  &none  &none
                                    &none         &trans        &trans          &none  &none        &none
             >;


### PR DESCRIPTION
- 修改 `game_option_layer` 的綁定
- 更改 `Option` 圖層中的數字按鍵綁定
