### PR TITLE
功能: 重新設計鍵盤快捷鍵以進行選項導航

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -127,18 +127,11 @@
             layers = <0 1 2 3 4 5 6 7>;
         };
 
-        combo_TAB_WIN {
+        combo_CTRL_TAB {
             bindings = <&kp LC(TAB)>;
             key-positions = <21 22>;
             timeout-ms = <100>;
-            layers = <0 1 2 3>;
-        };
-
-        combo_TAB_MAC {
-            bindings = <&kp LG(TAB)>;
-            key-positions = <21 22>;
-            timeout-ms = <100>;
-            layers = <4 5 6 7>;
+            layers = <0 1 2 3 4 5 6 7>;
         };
 
         combo_TD_MULTI_WIN {


### PR DESCRIPTION
- 將 `combo_TAB_WIN` 組合鍵修改為 `combo_CTRL_TAB`
- 移除 `combo_TAB_MAC` 組合鍵
- 將所有圖層添加到 `combo_CTRL_TAB` 組合鍵中
