### PR TITLE
性能優化：優化按鍵綁定超時和輕拍期間

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -109,28 +109,28 @@
         combo_TAB {
             bindings = <&kp TAB>;
             key-positions = <1 2>;
-            timeout-ms = <100>;
+            timeout-ms = <20>;
             layers = <0 1 2 3 4 5 6 7>;
         };
 
         combo_BACKSPACE {
             bindings = <&bspc_del>;
             key-positions = <9 10>;
-            timeout-ms = <100>;
+            timeout-ms = <20>;
             layers = <0 1 2 3 4 5 6 7>;
         };
 
         combo_ESC {
             bindings = <&kp ESC>;
             key-positions = <13 14>;
-            timeout-ms = <100>;
+            timeout-ms = <20>;
             layers = <0 1 2 3 4 5 6 7>;
         };
 
         combo_CTRL_TAB {
             bindings = <&kp LC(TAB)>;
             key-positions = <21 22>;
-            timeout-ms = <100>;
+            timeout-ms = <20>;
             layers = <0 1 2 3 4 5 6 7>;
         };
 
@@ -138,14 +138,14 @@
             bindings = <&td_multi_win>;
             key-positions = <33 34>;
             layers = <0 1 2 3>;
-            timeout-ms = <150>;
+            timeout-ms = <20>;
         };
 
         combo_TD_MULTI_MAC {
             bindings = <&td_multi_mac>;
             key-positions = <33 34>;
             layers = <4 5 6 7>;
-            timeout-ms = <150>;
+            timeout-ms = <20>;
         };
     };
 
@@ -178,7 +178,7 @@
             compatible = "zmk,behavior-tap-dance";
             label = "TAP_DANCE_MULTI_CMD";
             #binding-cells = <0>;
-            tapping-term-ms = <250>;
+            tapping-term-ms = <200>;
             bindings = <&kp LEFT_GUI>, <&kp LA(LEFT_GUI)>;
         };
 


### PR DESCRIPTION
- 將幾個組合鍵綁定的超時從100毫秒減少到20毫秒
- 將td_multi_cmd行為的輕拍期間從250毫秒減少到200毫秒
