### PR TITLE
develop

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -235,7 +235,7 @@
             bindings = <
 &none  &kp NUMBER_1      &kp NUMBER_2  &kp NUMBER_3  &kp NUMBER_4  &kp NUMBER_5    &kp NUMBER_6   &kp NUMBER_7     &kp NUMBER_8    &kp NUMBER_9  &kp NUMBER_0     &none
 &none  &kp LEFT_CONTROL  &none         &none         &kp MINUS     &kp HOME        &kp PAGE_UP    &kp LEFT_ARROW   &kp DOWN_ARROW  &kp UP_ARROW  &kp RIGHT_ARROW  &none
-&none  &kp ESC           &none         &none         &none         &kp END         &kp PAGE_DOWN  &LC(LA(DEL))     &kp LC(A)       &kp LC(Z)     &kp LC(TAB)      &none
+&none  &kp ESC           &none         &none         &none         &kp END         &kp PAGE_DOWN  &kp LC(LA(DEL))  &kp LC(A)       &kp LC(Z)     &kp LC(TAB)      &none
                                        &trans        &mo WIN_CODE  &trans          &trans         &trans           &trans
             >;
         };

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -127,6 +127,13 @@
             layers = <0 1 2 3 4 5 6 7>;
         };
 
+        combo_ESC {
+            bindings = <&kp ESC>;
+            key-positions = <25 26>;
+            timeout-ms = <20>;
+            layers = <0 1 2 3 4 5 6 7>;
+        };
+
         combo_BT_CLR {
             bindings = <&bt BT_CLR>;
             key-positions = <18 22>;

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -254,8 +254,8 @@
             label = "MacOS";
             bindings = <
 &none  &kp Q               &kp W  &kp E          &kp R         &kp T                   &kp Y      &kp U        &kp I               &kp O    &mod_pdel      &none
-&none  &kp A               &kp S  &kp D          &kp F         &kp G                   &kp H      &kp J        &kp K               &kp L    &kp SEMICOLON  &none
-&none  &mt LEFT_CONTROL Z  &kp X  &kp C          &kp V         &kp B                   &kp N      &kp M        &kp COMMA           &kp DOT  &kp SLASH      &none
+&none  &mt LEFT_CONTROL A  &kp S  &kp D          &kp F         &kp G                   &kp H      &kp J        &kp K               &kp L    &kp SEMICOLON  &none
+&none  &kp Z               &kp X  &kp C          &kp V         &kp B                   &kp N      &kp M        &kp COMMA           &kp DOT  &kp SLASH      &none
                                   &td_multi_cmd  &mo MAC_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER  &mo MAC_NUM  &kp LC(LEFT_SHIFT)
             >;
         };

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -113,8 +113,8 @@
             layers = <0 1 2 3 4 5 6 7>;
         };
 
-        combo_BACKSPACE {
-            bindings = <&bspc_del>;
+        combo_DEL {
+            bindings = <&kp DEL>;
             key-positions = <9 10>;
             timeout-ms = <20>;
             layers = <0 1 2 3 4 5 6 7>;
@@ -189,10 +189,10 @@
             bindings = <&kp LEFT_GUI>, <&kp LA(LEFT_GUI)>;
         };
 
-        bspc_del: backspace_delete {
+        mod_pdel: mof_p_delete {
             compatible = "zmk,behavior-mod-morph";
             #binding-cells = <0>;
-            bindings = <&kp BACKSPACE>, <&kp DELETE>;
+            bindings = <&kp P>, <&kp BACKSPACE>;
             mods = <(MOD_LSFT)>;
         };
 
@@ -213,7 +213,7 @@
         windows_default_layer {
             label = "Windows";
             bindings = <
-&none  &kp Q               &kp W  &kp E          &kp R         &kp T                   &kp Y      &kp U        &kp I               &kp O    &kp P          &none
+&none  &kp Q               &kp W  &kp E          &kp R         &kp T                   &kp Y      &kp U        &kp I               &kp O    &mof_p_delete  &none
 &none  &mt LEFT_CONTROL A  &kp S  &kp D          &kp F         &kp G                   &kp H      &kp J        &kp K               &kp L    &kp SEMICOLON  &none
 &none  &kp Z               &kp X  &kp C          &kp V         &kp B                   &kp N      &kp M        &kp COMMA           &kp DOT  &kp SLASH      &none
                                   &td_multi_alt  &mo WIN_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER  &mo WIN_NUM  &kp LC(LEFT_SHIFT)
@@ -253,7 +253,7 @@
         mac_default_layer {
             label = "MacOS";
             bindings = <
-&none  &kp Q               &kp W  &kp E          &kp R         &kp T                   &kp Y      &kp U        &kp I               &kp O    &kp P          &none
+&none  &kp Q               &kp W  &kp E          &kp R         &kp T                   &kp Y      &kp U        &kp I               &kp O    &mof_p_delete  &none
 &none  &kp A               &kp S  &kp D          &kp F         &kp G                   &kp H      &kp J        &kp K               &kp L    &kp SEMICOLON  &none
 &none  &mt LEFT_CONTROL Z  &kp X  &kp C          &kp V         &kp B                   &kp N      &kp M        &kp COMMA           &kp DOT  &kp SLASH      &none
                                   &td_multi_cmd  &mo MAC_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER  &mo MAC_NUM  &kp LC(LEFT_SHIFT)

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -120,13 +120,6 @@
             layers = <0 1 2 3 4 5 6 7>;
         };
 
-        combo_ESC {
-            bindings = <&kp ESC>;
-            key-positions = <13 14>;
-            timeout-ms = <20>;
-            layers = <0 1 2 3 4 5 6 7>;
-        };
-
         combo_CTRL_TAB {
             bindings = <&kp LC(TAB)>;
             key-positions = <21 22>;

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -189,7 +189,7 @@
             bindings = <&kp LEFT_GUI>, <&kp LA(LEFT_GUI)>;
         };
 
-        mod_pdel: mof_p_delete {
+        mod_pdel: mod_p_delete {
             compatible = "zmk,behavior-mod-morph";
             #binding-cells = <0>;
             bindings = <&kp P>, <&kp BACKSPACE>;
@@ -213,7 +213,7 @@
         windows_default_layer {
             label = "Windows";
             bindings = <
-&none  &kp Q               &kp W  &kp E          &kp R         &kp T                   &kp Y      &kp U        &kp I               &kp O    &mof_p_delete  &none
+&none  &kp Q               &kp W  &kp E          &kp R         &kp T                   &kp Y      &kp U        &kp I               &kp O    &mod_pdel      &none
 &none  &mt LEFT_CONTROL A  &kp S  &kp D          &kp F         &kp G                   &kp H      &kp J        &kp K               &kp L    &kp SEMICOLON  &none
 &none  &kp Z               &kp X  &kp C          &kp V         &kp B                   &kp N      &kp M        &kp COMMA           &kp DOT  &kp SLASH      &none
                                   &td_multi_alt  &mo WIN_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER  &mo WIN_NUM  &kp LC(LEFT_SHIFT)
@@ -253,7 +253,7 @@
         mac_default_layer {
             label = "MacOS";
             bindings = <
-&none  &kp Q               &kp W  &kp E          &kp R         &kp T                   &kp Y      &kp U        &kp I               &kp O    &mof_p_delete  &none
+&none  &kp Q               &kp W  &kp E          &kp R         &kp T                   &kp Y      &kp U        &kp I               &kp O    &mod_pdel      &none
 &none  &kp A               &kp S  &kp D          &kp F         &kp G                   &kp H      &kp J        &kp K               &kp L    &kp SEMICOLON  &none
 &none  &mt LEFT_CONTROL Z  &kp X  &kp C          &kp V         &kp B                   &kp N      &kp M        &kp COMMA           &kp DOT  &kp SLASH      &none
                                   &td_multi_cmd  &mo MAC_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER  &mo MAC_NUM  &kp LC(LEFT_SHIFT)

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -214,8 +214,8 @@
             label = "Windows";
             bindings = <
 &none  &kp Q               &kp W  &kp E          &kp R         &kp T                   &kp Y      &kp U        &kp I               &kp O    &kp P          &none
-&none  &kp A               &kp S  &kp D          &kp F         &kp G                   &kp H      &kp J        &kp K               &kp L    &kp SEMICOLON  &none
-&none  &mt LEFT_CONTROL Z  &kp X  &kp C          &kp V         &kp B                   &kp N      &kp M        &kp COMMA           &kp DOT  &kp SLASH      &none
+&none  &mt LEFT_CONTROL A  &kp S  &kp D          &kp F         &kp G                   &kp H      &kp J        &kp K               &kp L    &kp SEMICOLON  &none
+&none  &kp Z               &kp X  &kp C          &kp V         &kp B                   &kp N      &kp M        &kp COMMA           &kp DOT  &kp SLASH      &none
                                   &td_multi_alt  &mo WIN_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER  &mo WIN_NUM  &kp LC(LEFT_SHIFT)
             >;
         };
@@ -224,8 +224,8 @@
             label = "WinCode";
             bindings = <
 &none  &kp EXCLAMATION   &kp AT  &kp HASH           &kp DOLLAR      &kp PERCENT    &kp CARET  &kp AMPERSAND      &kp STAR              &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &none
-&none  &kp ESC           &none   &kp LA(LS(EQUAL))  &kp MINUS       &kp EQUAL      &kp GRAVE  &kp SINGLE_QUOTE   &kp NON_US_BACKSLASH  &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &none
-&none  &sk LEFT_CONTROL  &none   &kp LA(LS(MINUS))  &kp UNDERSCORE  &kp PLUS       &kp TILDE  &kp DOUBLE_QUOTES  &kp PIPE              &kp LEFT_BRACE        &kp RIGHT_BRACE        &none
+&none  &kp LEFT_CONTROL  &none   &kp LA(LS(EQUAL))  &kp MINUS       &kp EQUAL      &kp GRAVE  &kp SINGLE_QUOTE   &kp NON_US_BACKSLASH  &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &none
+&none  &kp ESC           &none   &kp LA(LS(MINUS))  &kp UNDERSCORE  &kp PLUS       &kp TILDE  &kp DOUBLE_QUOTES  &kp PIPE              &kp LEFT_BRACE        &kp RIGHT_BRACE        &none
                                  &trans             &trans          &trans         &trans     &mo WIN_NUM        &trans
             >;
         };
@@ -234,8 +234,8 @@
             label = "WinNum";
             bindings = <
 &none  &kp NUMBER_1      &kp NUMBER_2  &kp NUMBER_3  &kp NUMBER_4  &kp NUMBER_5    &kp NUMBER_6   &kp NUMBER_7     &kp NUMBER_8    &kp NUMBER_9  &kp NUMBER_0     &none
-&none  &kp ESC           &none         &none         &kp MINUS     &kp HOME        &kp PAGE_UP    &kp LEFT_ARROW   &kp DOWN_ARROW  &kp UP_ARROW  &kp RIGHT_ARROW  &none
-&none  &sk LEFT_CONTROL  &none         &none         &none         &kp END         &kp PAGE_DOWN  &none            &kp LC(A)       &kp LC(Z)     &kp LC(TAB)      &none
+&none  &kp LEFT_CONTROL  &none         &none         &kp MINUS     &kp HOME        &kp PAGE_UP    &kp LEFT_ARROW   &kp DOWN_ARROW  &kp UP_ARROW  &kp RIGHT_ARROW  &none
+&none  &kp ESC           &none         &none         &none         &kp END         &kp PAGE_DOWN  &LC(LA(DEL))     &kp LC(A)       &kp LC(Z)     &kp LC(TAB)      &none
                                        &trans        &mo WIN_CODE  &trans          &trans         &trans           &trans
             >;
         };
@@ -243,10 +243,10 @@
         windows_function_layer {
             label = "WinFunc";
             bindings = <
-&none  &kp F1                &kp F2   &kp F3          &kp F4      &kp F5              &bt BT_SEL 0  &bt BT_SEL 1     &bt BT_SEL 2       &bt BT_SEL 3  &bt BT_SEL 4  &none
-&none  &kp F6                &kp F7   &kp F8          &kp F9      &kp F10             &none         &to MAC_DEF      &to GAME_DEF       &none         &none         &none
-&none  &mt LEFT_CONTROL F11  &kp F12  &kp C_PREVIOUS  &kp C_NEXT  &kp C_PLAY_PAUSE    &kp C_MUTE    &kp C_VOLUME_UP  &kp C_VOLUME_DOWN  &none         &none         &none
-                                      &trans          &trans      &trans              &trans        &trans           &trans
+&none  &kp F1               &kp F2   &kp F3          &kp F4      &kp F5              &bt BT_SEL 0  &bt BT_SEL 1     &bt BT_SEL 2       &bt BT_SEL 3  &bt BT_SEL 4  &none
+&none  &mt LEFT_CONTROL F6  &kp F7   &kp F8          &kp F9      &kp F10             &none         &to MAC_DEF      &to GAME_DEF       &none         &none         &none
+&none  &kp F11              &kp F12  &kp C_PREVIOUS  &kp C_NEXT  &kp C_PLAY_PAUSE    &kp C_MUTE    &kp C_VOLUME_UP  &kp C_VOLUME_DOWN  &none         &none         &none
+                                     &trans          &trans      &trans              &trans        &trans           &trans
             >;
         };
 
@@ -263,29 +263,29 @@
         mac_code_layer {
             label = "MacCode";
             bindings = <
-&none  &kp EXCLAMATION   &kp AT           &kp HASH       &kp DOLLAR      &kp PERCENT    &kp CARET  &kp AMPERSAND      &kp STAR              &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &none
-&none  &kp ESC           &fullscreen_mac  &kp LG(D)      &kp MINUS       &kp EQUAL      &kp GRAVE  &kp SINGLE_QUOTE   &kp NON_US_BACKSLASH  &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &none
-&none  &sk LEFT_CONTROL  &none            &kp LG(LS(D))  &kp UNDERSCORE  &kp PLUS       &kp TILDE  &kp DOUBLE_QUOTES  &kp PIPE              &kp LEFT_BRACE        &kp RIGHT_BRACE        &none
-                                          &trans         &trans          &trans         &trans     &mo MAC_NUM        &trans
+&none  &kp EXCLAMATION   &kp AT         &kp HASH       &kp DOLLAR      &kp PERCENT    &kp CARET  &kp AMPERSAND      &kp STAR              &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &none
+&none  &kp LEFT_CONTROL  &kp LG(LC(F))  &kp LG(D)      &kp MINUS       &kp EQUAL      &kp GRAVE  &kp SINGLE_QUOTE   &kp NON_US_BACKSLASH  &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &none
+&none  &kp ESC           &none          &kp LG(LS(D))  &kp UNDERSCORE  &kp PLUS       &kp TILDE  &kp DOUBLE_QUOTES  &kp PIPE              &kp LEFT_BRACE        &kp RIGHT_BRACE        &none
+                                        &trans         &trans          &trans         &trans     &mo MAC_NUM        &trans
             >;
         };
 
         mac_number_layer {
             label = "MacNum";
             bindings = <
-&none  &kp NUMBER_1      &kp NUMBER_2     &kp NUMBER_3  &kp NUMBER_4  &kp NUMBER_5    &kp NUMBER_6   &kp NUMBER_7    &kp NUMBER_8     &kp NUMBER_9  &kp NUMBER_0     &none
-&none  &kp ESC           &fullscreen_mac  &none         &kp MINUS     &kp HOME        &kp PAGE_UP    &kp LEFT_ARROW  &kp DOWN_ARROW   &kp UP_ARROW  &kp RIGHT_ARROW  &none
-&none  &sk LEFT_CONTROL  &none            &none         &none         &kp END         &kp PAGE_DOWN  &none           &kp LC(A)        &kp LG(Z)     &kp LC(TAB)      &none
-                                          &trans        &mo MAC_CODE  &trans          &trans         &trans          &trans
+&none  &kp NUMBER_1      &kp NUMBER_2   &kp NUMBER_3  &kp NUMBER_4  &kp NUMBER_5    &kp NUMBER_6   &kp NUMBER_7    &kp NUMBER_8     &kp NUMBER_9  &kp NUMBER_0     &none
+&none  &kp LEFT_CONTROL  &kp LG(LC(F))  &none         &kp MINUS     &kp HOME        &kp PAGE_UP    &kp LEFT_ARROW  &kp DOWN_ARROW   &kp UP_ARROW  &kp RIGHT_ARROW  &none
+&none  &kp ESC           &none          &none         &none         &kp END         &kp PAGE_DOWN  &none           &kp LC(A)        &kp LG(Z)     &kp LC(TAB)      &none
+                                        &trans        &mo MAC_CODE  &trans          &trans         &trans          &trans
             >;
         };
 
         mac_function_layer {
             label = "MacFunc";
             bindings = <
-&none  &kp F1                &kp F2   &kp F3          &kp F4      &kp F5              &bt BT_SEL 0  &bt BT_SEL 1     &bt BT_SEL 2        &bt BT_SEL 3  &bt BT_SEL 4  &none
-&none  &kp F6                &kp F7   &kp F8          &kp F9      &kp F10             &none         &to WIN_DEF      &to GAME_DEF        &none         &none         &none
-&none  &mt LEFT_CONTROL F11  &kp F12  &kp C_PREVIOUS  &kp C_NEXT  &kp C_PLAY_PAUSE    &kp C_MUTE    &kp C_VOLUME_UP  &kp C_VOLUME_DOWN   &none         &none         &none
+&none  &kp F1               &kp F2   &kp F3          &kp F4      &kp F5              &bt BT_SEL 0  &bt BT_SEL 1     &bt BT_SEL 2        &bt BT_SEL 3  &bt BT_SEL 4  &none
+&none  &mt LEFT_CONTROL F6  &kp F7   &kp F8          &kp F9      &kp F10             &none         &to WIN_DEF      &to GAME_DEF        &none         &none         &none
+&none  &kp F11              &kp F12  &kp C_PREVIOUS  &kp C_NEXT  &kp C_PLAY_PAUSE    &kp C_MUTE    &kp C_VOLUME_UP  &kp C_VOLUME_DOWN   &none         &none         &none
                                       &trans          &trans      &trans              &trans        &trans           &trans
             >;
         };


### PR DESCRIPTION
- 調整Control以及ESC按鍵位置
- 維護：更新 corne.keymap 中的按鍵綁定
- 功能: 更新 combo_ESC 和 combo_BT_CLR 的按鍵綁定
- 維護：更新刪除操作的鍵綁定
- 重構：更新按鍵綁定以使用`mod_pdel`行為
- 工作：更新 Windows 功能層的鍵綁定
- 事務: 更新 `mac_default_layer` 的按鍵綁定
