### PR TITLE
翻譯: 維護: 更新`config/corne.keymap`中`&#43;`和`&amp;`的按鍵綁定

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -249,10 +249,10 @@
         mac_code_layer {
             label = "MacCode";
             bindings = <
-&none  &kp EXCLAMATION   &kp AT         &kp HASH       &kp DOLLAR      &kp PERCENT    &kp CARET  &kp AMPERSAND      &kp STAR              &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &none
-&none  &kp LEFT_CONTROL  &kp LG(LC(F))  &kp LG(D)      &kp MINUS       &kp EQUAL      &kp GRAVE  &kp SINGLE_QUOTE   &kp NON_US_BACKSLASH  &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &none
-&none  &kp ESC           &LG(LA(ESC))   &kp LG(LS(D))  &kp UNDERSCORE  &kp PLUS       &kp TILDE  &kp DOUBLE_QUOTES  &kp PIPE              &kp LEFT_BRACE        &kp RIGHT_BRACE        &none
-                                        &trans         &trans          &trans         &trans     &mo MAC_NUM        &trans
+&none  &kp EXCLAMATION   &kp AT           &kp HASH       &kp DOLLAR      &kp PERCENT    &kp CARET  &kp AMPERSAND      &kp STAR              &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &none
+&none  &kp LEFT_CONTROL  &kp LG(LC(F))    &kp LG(D)      &kp MINUS       &kp EQUAL      &kp GRAVE  &kp SINGLE_QUOTE   &kp NON_US_BACKSLASH  &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &none
+&none  &kp ESC           &kp LG(LA(ESC))  &kp LG(LS(D))  &kp UNDERSCORE  &kp PLUS       &kp TILDE  &kp DOUBLE_QUOTES  &kp PIPE              &kp LEFT_BRACE        &kp RIGHT_BRACE        &none
+                                          &trans         &trans          &trans         &trans     &mo MAC_NUM        &trans
             >;
         };
 


### PR DESCRIPTION
- 修改`config/corne.keymap`檔案
- 將第257行的`&#43;`綁定從`none`改為`kp ESC`
- 將第261行的`&amp;`綁定從`none`改為`kp ESC`
- 將第262行的`&amp;`綁定從`none`改為`kp KP_1`

Signed-off-by: DAST-OfficePC <jackie@dast.tw>
